### PR TITLE
Enrichment interface change

### DIFF
--- a/gnip_analysis_config/enrichments/enrichment_base.py
+++ b/gnip_analysis_config/enrichments/enrichment_base.py
@@ -13,6 +13,7 @@ class GenericModelEnrichment(object):
         if "enrichments" not in tweet:
             tweet['enrichments'] = {}
         tweet['enrichments'][self.__class__.__name__] = enrichment_value
+        return tweet
 
 
 class BaseEnrichment(object):
@@ -30,5 +31,6 @@ class BaseEnrichment(object):
         if "enrichments" not in tweet:
             tweet['enrichments'] = {}
         tweet['enrichments'][self.__class__.__name__] = self.enrichment_value(tweet)
+        return tweet
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-setup(name='gnip_analysis_tools',
+setup(name='Gnip-Analysis-Tools',
         packages=find_packages(),
         version='0.1',
         license='MIT',
@@ -8,5 +8,5 @@ setup(name='gnip_analysis_tools',
         author_email='jeffakolb@gmail.com',
         description='Configuration tools for Gnip-Analysis-Pipeline',  
         extras_require = {'nltk' : 'nltk'},
-        url='https://github.com/jeffakolb/Gnip-Analysis-Tools',
+        url='https://github.com/tw-ddis/Gnip-Analysis-Tools',
         )


### PR DESCRIPTION
To better support concurrent and parallel enrichment of tweets, we need to change the interface for enrichments. Specifically, the `enrich` method of enrichment classes will now return the tweet dictionary, instead of mutating the tweet dictionary that has been passed in as the function's argument. 

This is implemented with the addition of a return statement in the `enrich` methods defined in `enrichments/enrichment_base.py`.

The corresponding changes to `tweet_enricher.py` in the Gnip-Analysis-Pipeline will be made backward compatible. 