### PR TITLE
Update measurement_list variable name

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ from your working directory, you would create an enrichments configuration file
 
 from gnip_analysis_tools.measurements.test_measurements import TweetCounter,ReTweetCounter
 
-enrichment_class_list = [TweetCounter,ReTweetCounter]
+measurement_class_list = [TweetCounter,ReTweetCounter]
 ```
 
 We can the build time series from the Tweets in `my_enriched_tweets.json` as follows:


### PR DESCRIPTION
In the code snippet for "Measurements", the variable name used was `enrichment_class_list`. But, per the example module ( https://github.com/tw-ddis/Gnip-Analysis-Pipeline/blob/master/example/my_measurements.py#L26 ), `measurement_class_list` is preferred (and less confusing).